### PR TITLE
Improve cleanup and Velocity support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Alle bemerkenswerten Änderungen an diesem Projekt werden in dieser Datei dokume
 
 Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/).
 
+## [1.2.1] - 2025
+
+### Hinzugefügt
+- Unterstützung für Velocity-Proxys mit einfachem Version-Befehl
+- velocity-plugin.json zur Registrierung auf Velocity
+
+### Behoben
+- Aufräumen von Chat- und Nachrichten-Daten beim Spieleraustritt
+
+## [1.2.2] - 2025
+
+### Hinzugefügt
+- Benachrichtigung neuer Reports über Discord-Webhook
+
 ## [1.2.0] - 2023
 
 ### Hinzugefügt

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # BungeeSystem
 
 ## Beschreibung
-Das **BungeeSystem** ist ein Plugin für BungeeCord, das verschiedene administrative und spielerbezogene Funktionen bietet. Es ermöglicht eine zentrale Steuerung des Netzwerks mit nützlichen Befehlen und Automatisierungen.
+Das **BungeeSystem** ist ein Plugin für BungeeCord und seit Version 1.2.1 auch für Velocity, das verschiedene administrative und spielerbezogene Funktionen bietet. Es ermöglicht eine zentrale Steuerung des Netzwerks mit nützlichen Befehlen und Automatisierungen.
 
 ## Funktionen
-- **Netzwerkweite Verwaltung**: Steuere dein BungeeCord-Netzwerk mit einfachen Befehlen.
+- **Netzwerkweite Verwaltung**: Steuere dein BungeeCord- oder Velocity-Netzwerk mit einfachen Befehlen.
 - **Benutzerfreundliche GUI**: Erleichtert die Nutzung für Admins und Moderatoren.
 - **Bann- und Mutesystem**: Verwalte Bestrafungen direkt über BungeeCord.
 - **Automatische Nachrichten**: Ankündigungen und Auto-Broadcasts für Spieler.
@@ -12,11 +12,12 @@ Das **BungeeSystem** ist ein Plugin für BungeeCord, das verschiedene administra
 - **Spielerstatistiken**: Tracking von Spieleraktivitäten (Onlinezeit, Logins, Votes) mit Ranglisten.
 - **Quality-of-Life Funktionen**: AFK-Status, Nicknamen, Spielersuche und mehr.
 - **Verbesserte Datenbankverwaltung**: Effiziente Speicherung und Abruf von Daten mit Caching.
+- **Report-System**: Spieler können Regelverstöße melden; optionaler Discord-Webhook zur Benachrichtigung.
 
 ## Installation
 1. Lade das Plugin von [GitHub](https://github.com/DerGamer009/BungeeSystem) herunter.
-2. Platziere die `.jar`-Datei im `plugins`-Ordner deines **BungeeCord**-Proxys.
-3. Starte den Proxy neu oder lade das Plugin mit `/bungee reload`.
+2. Platziere die `.jar`-Datei im `plugins`-Ordner deines **BungeeCord**- oder **Velocity**-Proxys.
+3. Starte den Proxy neu oder lade das Plugin mit `/bungee reload` (bzw. bei Velocity mit `/velocity reload`).
 4. Passe die Konfigurationsdatei in `plugins/BungeeSystem/config.yml` nach deinen Wünschen an.
 
 ## Befehle
@@ -36,6 +37,7 @@ Das **BungeeSystem** ist ein Plugin für BungeeCord, das verschiedene administra
 | `/seen <Spieler>`    | Zeigt die letzte Aktivität eines Spielers |
 | `/nick <Nickname>`   | Ändert deinen Anzeigenamen             |
 | `/whois <Spieler>`   | Zeigt Informationen über einen Spieler |
+| `/bsversion`         | Zeigt die aktuell installierte Version (Velocity) |
 
 ## Berechtigungen
 | Permission             | Beschreibung |
@@ -57,6 +59,7 @@ Das Plugin verwendet ein Manager-System für bessere Organisation:
 
 ## Konfiguration
 Die Konfigurationsdatei befindet sich unter `plugins/BungeeSystem/config.yml` und erlaubt die Anpassung von Nachrichten, Berechtigungen und weiteren Funktionen.
+Um Discord-Benachrichtigungen für neue Reports zu aktivieren, setze dort die Option `webhookUrl` auf deinen Webhook-Link.
 
 ## Lizenz
 Dieses Plugin wird unter der **MIT-Lizenz** veröffentlicht. Mehr Details findest du in der `LICENSE`-Datei.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BungeeSystem
 
 ## Beschreibung
-Das **BungeeSystem** ist ein Plugin für BungeeCord und seit Version 1.2.1 auch für Velocity, das verschiedene administrative und spielerbezogene Funktionen bietet. Es ermöglicht eine zentrale Steuerung des Netzwerks mit nützlichen Befehlen und Automatisierungen.
+Das **BungeeSystem** ist ein Plugin für BungeeCord und seit Version 1.2.2 auch für Velocity, das verschiedene administrative und spielerbezogene Funktionen bietet. Es ermöglicht eine zentrale Steuerung des Netzwerks mit nützlichen Befehlen und Automatisierungen.
 
 ## Funktionen
 - **Netzwerkweite Verwaltung**: Steuere dein BungeeCord- oder Velocity-Netzwerk mit einfachen Befehlen.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.dergamer09</groupId>
   <artifactId>BungeeSystem</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>BungeeSystem</name>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
           <version>5.4</version>
           <scope>provided</scope>
       </dependency>
+      <dependency>
+          <groupId>com.velocitypowered</groupId>
+          <artifactId>velocity-api</artifactId>
+          <version>3.1.1</version>
+          <scope>provided</scope>
+      </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/me/dergamer09/bungeesystem/BungeeSystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/BungeeSystem.java
@@ -19,7 +19,7 @@ public final class BungeeSystem extends Plugin {
     private static BungeeSystem instance;
     
     // Version information
-    private final String currentVersion = "1.2.0-SNAPSHOT";
+    private final String currentVersion = "1.2.2-SNAPSHOT";
     
     // Management systems
     private DatabaseManager databaseManager;

--- a/src/main/java/me/dergamer09/bungeesystem/Managers/ChatManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/Managers/ChatManager.java
@@ -240,6 +240,16 @@ public class ChatManager {
     public boolean hasGlobalChatEnabled(ProxiedPlayer player) {
         return globalChatEnabled.contains(player.getUniqueId());
     }
+
+    /**
+     * Remove a player's chat state when they disconnect to avoid memory leaks.
+     *
+     * @param uuid The UUID of the disconnecting player
+     */
+    public void handlePlayerDisconnect(UUID uuid) {
+        playerChannels.remove(uuid);
+        globalChatEnabled.remove(uuid);
+    }
     
     /**
      * Send a global chat message to all players on the network

--- a/src/main/java/me/dergamer09/bungeesystem/Managers/PunishmentManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/Managers/PunishmentManager.java
@@ -1214,9 +1214,13 @@ public class PunishmentManager {
                     "reason", reasonName,
                     "id", String.valueOf(reportId))));
             
+
             // Notify online staff members
             notifyStaffOfReport(targetName, senderName, reasonName, customReason, serverName, reportId);
-            
+
+            // Send Discord webhook if configured
+            sendReportToWebhook(targetName, senderName, reasonName, customReason, serverName, reportId);
+
             return true;
             
         } catch (SQLException e) {
@@ -1274,7 +1278,7 @@ public class PunishmentManager {
      * @param serverName Server where the reported player is
      * @param reportId Report ID
      */
-    private void notifyStaffOfReport(String playerName, String reporterName, String reasonName, 
+    private void notifyStaffOfReport(String playerName, String reporterName, String reasonName,
             String customReason, String serverName, int reportId) {
         
         String formattedReason = reasonName;
@@ -1298,6 +1302,47 @@ public class PunishmentManager {
         
         // Also log to console
         ProxyServer.getInstance().getConsole().sendMessage(new TextComponent(notification));
+    }
+
+    /**
+     * Send a Discord webhook notification about a new report if configured.
+     */
+    private void sendReportToWebhook(String playerName, String reporterName, String reasonName, String customReason,
+                                     String serverName, int reportId) {
+        String webhook = plugin.getWebhookUrl();
+        if (webhook == null || webhook.isEmpty() || webhook.contains("your-discord-webhook-url")) {
+            return; // webhook not configured
+        }
+
+        String formattedReason = reasonName;
+        if (customReason != null && !customReason.isEmpty()) {
+            formattedReason += ": " + customReason;
+        }
+
+        String content = "**Neuer Report**\n" +
+                "Spieler: " + playerName + "\n" +
+                "Reporter: " + reporterName + "\n" +
+                "Grund: " + formattedReason + "\n" +
+                "Server: " + serverName + "\n" +
+                "ID: " + reportId;
+
+        try {
+            java.net.URL url = new java.net.URL(webhook);
+            java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setDoOutput(true);
+
+            String payload = "{\"content\":\"" + content.replace("\"", "\\\"") + "\"}";
+            try (java.io.OutputStream os = conn.getOutputStream()) {
+                os.write(payload.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            }
+
+            conn.getResponseCode();
+            conn.disconnect();
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to send Discord webhook: " + e.getMessage());
+        }
     }
     
     /**

--- a/src/main/java/me/dergamer09/bungeesystem/listeners/PlayerEventListener.java
+++ b/src/main/java/me/dergamer09/bungeesystem/listeners/PlayerEventListener.java
@@ -92,7 +92,15 @@ public class PlayerEventListener implements Listener {
             
             // Clear AFK status
             AfkCommand.clearAfk(uuid);
-            
+
+            // Cleanup chat state
+            plugin.getChatManager().handlePlayerDisconnect(uuid);
+
+            // Remove messaging data to avoid memory leaks
+            BungeeSystem.lastMessageMap.remove(uuid);
+            BungeeSystem.lastMessageMap.entrySet().removeIf(e -> uuid.equals(e.getValue()));
+            BungeeSystem.ignoredPlayers.remove(uuid);
+
         } catch (SQLException e) {
             e.printStackTrace();
         }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/ReportCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/ReportCommand.java
@@ -1,0 +1,81 @@
+package me.dergamer09.bungeesystem.velocity;
+
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.Component;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+/**
+ * Simple /report command for Velocity that sends a message to the configured Discord webhook.
+ */
+public class ReportCommand implements SimpleCommand {
+
+    private final ProxyServer server;
+    private final String webhookUrl;
+
+    public ReportCommand(ProxyServer server, String webhookUrl) {
+        this.server = server;
+        this.webhookUrl = webhookUrl;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+
+        if (!(source instanceof Player)) {
+            source.sendMessage(Component.text("Only players can use this command."));
+            return;
+        }
+
+        if (args.length < 2) {
+            source.sendMessage(Component.text("Usage: /report <player> <reason> [details]"));
+            return;
+        }
+
+        Player reporter = (Player) source;
+        String target = args[0];
+        String reason = args[1];
+        String details = args.length > 2 ? String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : "";
+        String serverName = reporter.getCurrentServer().map(s -> s.getServerInfo().getName()).orElse("Unknown");
+
+        String content = "**Neuer Report**\n" +
+                "Spieler: " + target + "\n" +
+                "Reporter: " + reporter.getUsername() + "\n" +
+                "Grund: " + reason + (details.isEmpty() ? "" : " - " + details) + "\n" +
+                "Server: " + serverName;
+
+        sendWebhook(content);
+        source.sendMessage(Component.text("Report gesendet."));
+    }
+
+    private void sendWebhook(String message) {
+        if (webhookUrl == null || webhookUrl.isEmpty() || webhookUrl.contains("your-discord-webhook-url")) {
+            return;
+        }
+        try {
+            URL url = new URL(webhookUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setDoOutput(true);
+
+            String payload = "{\"content\":\"" + message.replace("\"", "\\\"") + "\"}";
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(payload.getBytes(StandardCharsets.UTF_8));
+            }
+            conn.getResponseCode();
+            conn.disconnect();
+        } catch (Exception e) {
+            server.getConsoleCommandSource().sendMessage(Component.text("Webhook Error: " + e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
@@ -1,0 +1,69 @@
+package me.dergamer09.bungeesystem.velocity;
+
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.ProxyServer;
+import org.slf4j.Logger;
+
+/**
+ * Minimal Velocity entry point for BungeeSystem.
+ * It currently only logs a startup message, but allows the
+ * plugin jar to be loaded on Velocity proxies.
+ */
+@Plugin(id = "bungeesystem", name = "BungeeSystem", version = "1.2.0-SNAPSHOT")
+public class VelocitySystem {
+
+    private static final String VERSION = "1.2.0-SNAPSHOT";
+
+    private final ProxyServer server;
+    private final Logger logger;
+    private String webhookUrl = "";
+
+    @Inject
+    public VelocitySystem(ProxyServer server, Logger logger) {
+        this.server = server;
+        this.logger = logger;
+    }
+
+    @Subscribe
+    public void onProxyInit(ProxyInitializeEvent event) {
+        webhookUrl = loadWebhook();
+        logger.info("BungeeSystem loaded (Velocity compatibility mode).");
+        // Register commands
+        server.getCommandManager().register(
+                server.getCommandManager().metaBuilder("bsversion").plugin(this).build(),
+                new VersionCommand(VERSION)
+        );
+        server.getCommandManager().register(
+                server.getCommandManager().metaBuilder("report").plugin(this).build(),
+                new ReportCommand(server, webhookUrl)
+        );
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        logger.info("BungeeSystem disabled (Velocity compatibility mode).");
+    }
+
+    private String loadWebhook() {
+        java.nio.file.Path path = java.nio.file.Paths.get("plugins", "BungeeSystem", "config.yml");
+        if (!java.nio.file.Files.exists(path)) {
+            return "";
+        }
+        java.util.regex.Pattern p = java.util.regex.Pattern.compile("webhookUrl:\\s*\"?(.*?)\"?$");
+        try {
+            for (String line : java.nio.file.Files.readAllLines(path)) {
+                java.util.regex.Matcher m = p.matcher(line.trim());
+                if (m.find()) {
+                    return m.group(1);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to read webhookUrl: {}", e.getMessage());
+        }
+        return "";
+    }
+}

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
@@ -13,10 +13,10 @@ import org.slf4j.Logger;
  * It currently only logs a startup message, but allows the
  * plugin jar to be loaded on Velocity proxies.
  */
-@Plugin(id = "bungeesystem", name = "BungeeSystem", version = "1.2.0-SNAPSHOT")
+@Plugin(id = "bungeesystem", name = "BungeeSystem", version = "1.2.2-SNAPSHOT")
 public class VelocitySystem {
 
-    private static final String VERSION = "1.2.0-SNAPSHOT";
+    private static final String VERSION = "1.2.2-SNAPSHOT";
 
     private final ProxyServer server;
     private final Logger logger;

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VersionCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VersionCommand.java
@@ -1,0 +1,24 @@
+package me.dergamer09.bungeesystem.velocity;
+
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Simple command to display the current plugin version on Velocity.
+ */
+public class VersionCommand implements SimpleCommand {
+
+    private final String version;
+
+    public VersionCommand(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        source.sendMessage(Component.text("BungeeSystem version " + version));
+    }
+}

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,0 +1,7 @@
+{
+  "id": "bungeesystem",
+  "name": "BungeeSystem",
+  "version": "${project.version}",
+  "main": "me.dergamer09.bungeesystem.velocity.VelocitySystem",
+  "author": "DerGamer09"
+}


### PR DESCRIPTION
## Summary
- clean up chat and private message data on player disconnect
- introduce a Velocity version command and shutdown logging
- document Velocity support in README
- note new version in changelog
- send report notifications to a configurable Discord webhook
- add a simple report command for Velocity
- add velocity-plugin.json for Velocity proxies
- document the descriptor in the changelog

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfb2e57c4832ea725138b0e84e106