### PR TITLE
Fix Velocity build errors

### DIFF
--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/CommandManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/CommandManager.java
@@ -16,7 +16,7 @@ public class CommandManager {
     }
 
     public void registerCommands() {
-        var cm = plugin.getServer().getCommandManager();
+        com.velocitypowered.api.command.CommandManager cm = plugin.getServer().getCommandManager();
         cm.register(cm.metaBuilder("bsversion").plugin(plugin).build(), new VersionCommand(plugin.getVersion()));
         cm.register(cm.metaBuilder("ping").plugin(plugin).build(), new PingCommand());
 

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ListenerManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ListenerManager.java
@@ -1,7 +1,7 @@
 package me.dergamer09.bungeesystem.velocity.Managers;
 
 import com.velocitypowered.api.event.Subscribe;
-import com.velocitypowered.api.event.player.PlayerDisconnectEvent;
+import com.velocitypowered.api.event.connection.DisconnectEvent;
 import me.dergamer09.bungeesystem.velocity.VelocitySystem;
 import org.slf4j.Logger;
 
@@ -23,7 +23,7 @@ public class ListenerManager {
 
     // Example listener for disconnects
     @Subscribe
-    public void onDisconnect(PlayerDisconnectEvent event) {
+    public void onDisconnect(DisconnectEvent event) {
         logger.info(event.getPlayer().getUsername() + " disconnected.");
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
@@ -52,7 +52,8 @@ public class VelocitySystem {
         listenerManager.registerListeners();
 
         // Schedule placeholder task
-        server.getScheduler().buildTask(this, new OnlineTimeUpdater(this)).repeat(1L).schedule();
+        server.getScheduler().buildTask(this, new OnlineTimeUpdater(this))
+                .repeat(java.time.Duration.ofSeconds(1)).schedule();
     }
 
     @Subscribe


### PR DESCRIPTION
## Summary
- use Velocity DisconnectEvent for disconnect handling
- avoid `var` in Velocity CommandManager for Java 8
- use Duration in Velocity scheduler

## Testing
- `java -version`

------
https://chatgpt.com/codex/tasks/task_e_685d4d4e285c832e82bdbc6bebb49c72