### PR TITLE
Fix Velocity Guice data directory injection

### DIFF
--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
@@ -6,6 +6,7 @@ import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 import java.nio.file.Path;
@@ -32,7 +33,7 @@ public class VelocitySystem {
     private ListenerManager listenerManager;
 
     @Inject
-    public VelocitySystem(ProxyServer server, Logger logger, @com.google.inject.name.Named("dataDirectory") Path dataDirectory) {
+    public VelocitySystem(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
         this.server = server;
         this.logger = logger;
         this.dataDirectory = dataDirectory;


### PR DESCRIPTION
## Summary
- use Velocity `@DataDirectory` annotation instead of Guice `@Named("dataDirectory")`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5db7bc7c832eb337f2ced9735d14