### PR TITLE
Fix missing config classes on Velocity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,13 @@
           <version>1.21-R0.2</version>
           <scope>provided</scope>
       </dependency>
+      <!-- Include BungeeCord's configuration library so Velocity has access
+           to net.md_5.bungee.config.* classes at runtime -->
+      <dependency>
+          <groupId>net.md-5</groupId>
+          <artifactId>bungeecord-config</artifactId>
+          <version>1.21-R0.2</version>
+      </dependency>
       <dependency>
           <groupId>com.googlecode.json-simple</groupId>
           <artifactId>json-simple</artifactId>


### PR DESCRIPTION
## Summary
- include `bungeecord-config` so Velocity has `YamlConfiguration`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d5eed4ac8832ebb5b6825c07d575a