### PR TITLE
Extend Velocity command support

### DIFF
--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ConfigManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ConfigManager.java
@@ -11,6 +11,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Simplified configuration manager for Velocity.
@@ -78,6 +81,11 @@ public class ConfigManager {
         return config;
     }
 
+    public void reloadAll() throws IOException {
+        loadConfig();
+        loadMessages();
+    }
+
     public String getMessage(String path) {
         if (messages == null) {
             return "§cMessages configuration not loaded.";
@@ -87,5 +95,57 @@ public class ConfigManager {
             return "§cMessage not found: " + path;
         }
         return ChatColor.translateAlternateColorCodes('&', message);
+    }
+
+    public String getMessage(String path, String... replacements) {
+        String message = getMessage(path);
+        if (replacements.length % 2 != 0) {
+            return message;
+        }
+        for (int i = 0; i < replacements.length; i += 2) {
+            message = message.replace("%" + replacements[i] + "%", replacements[i + 1]);
+        }
+        return message;
+    }
+
+    public List<UUID> getMaintenanceWhitelist() {
+        List<String> list = config.getStringList("maintenance.whitelist");
+        List<UUID> uuids = new ArrayList<>();
+        for (String uuidStr : list) {
+            try {
+                uuids.add(UUID.fromString(uuidStr));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        return uuids;
+    }
+
+    public void saveConfig() {
+        try {
+            ConfigurationProvider.getProvider(YamlConfiguration.class).save(config, configFile);
+        } catch (IOException e) {
+            logger.error("Error saving config", e);
+        }
+    }
+
+    public void addToWhitelist(UUID uuid) {
+        List<String> whitelist = config.getStringList("maintenance.whitelist");
+        if (!whitelist.contains(uuid.toString())) {
+            whitelist.add(uuid.toString());
+            config.set("maintenance.whitelist", whitelist);
+            saveConfig();
+        }
+    }
+
+    public void removeFromWhitelist(UUID uuid) {
+        List<String> whitelist = config.getStringList("maintenance.whitelist");
+        whitelist.remove(uuid.toString());
+        config.set("maintenance.whitelist", whitelist);
+        saveConfig();
+    }
+
+    public boolean isInWhitelist(UUID uuid) {
+        List<String> whitelist = config.getStringList("maintenance.whitelist");
+        return whitelist.contains(uuid.toString());
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/VelocityCommandManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/VelocityCommandManager.java
@@ -17,35 +17,35 @@ public class VelocityCommandManager {
 
     public void registerCommands() {
         com.velocitypowered.api.command.CommandManager cm = plugin.getServer().getCommandManager();
-        cm.register(cm.metaBuilder("bsversion").plugin(plugin).build(), new VersionCommand(plugin.getVersion()));
-        cm.register(cm.metaBuilder("ping").plugin(plugin).build(), new PingCommand());
+        cm.register(cm.metaBuilder("bsversion").plugin(plugin).build(), new VersionCommand(plugin, plugin.getVersion()));
+        cm.register(cm.metaBuilder("ping").plugin(plugin).build(), new PingCommand(plugin));
 
         // Register placeholders for other commands
-        registerPlaceholder(cm, "afk", new AfkCommand());
+        registerPlaceholder(cm, "afk", new AfkCommand(plugin));
         registerPlaceholder(cm, "ban", new BanCommand());
-        registerPlaceholder(cm, "blockbungee", new BlockBungeeCommand());
-        registerPlaceholder(cm, "broadcast", new BroadcastCommand());
-        registerPlaceholder(cm, "find", new FindCommand());
+        registerPlaceholder(cm, "blockbungee", new BlockBungeeCommand(plugin));
+        registerPlaceholder(cm, "broadcast", new BroadcastCommand(plugin));
+        registerPlaceholder(cm, "find", new FindCommand(plugin));
         registerPlaceholder(cm, "globalchat", new GlobalChatCommand());
         registerPlaceholder(cm, "ignore", new IgnoreCommand());
         registerPlaceholder(cm, "joinme", new JoinMeCommand());
-        registerPlaceholder(cm, "list", new ListCommand());
+        registerPlaceholder(cm, "list", new ListCommand(plugin));
         registerPlaceholder(cm, "lobby", new LobbyCommand());
         registerPlaceholder(cm, "msg", new MSGCommand());
-        registerPlaceholder(cm, "maintenance", new MaintenanceCommand());
+        registerPlaceholder(cm, "maintenance", new MaintenanceCommand(plugin));
         registerPlaceholder(cm, "mute", new MuteCommand());
-        registerPlaceholder(cm, "nick", new NickCommand());
+        registerPlaceholder(cm, "nick", new NickCommand(plugin));
         registerPlaceholder(cm, "onlinetime", new OnlineTimeCommand());
         registerPlaceholder(cm, "play", new PlayCommand());
-        registerPlaceholder(cm, "reloadconfig", new ReloadConfigCommand());
+        registerPlaceholder(cm, "reloadconfig", new ReloadConfigCommand(plugin));
         registerPlaceholder(cm, "reply", new ReplyCommand());
         registerPlaceholder(cm, "report", new ReportCommand());
         registerPlaceholder(cm, "reports", new ReportsCommand());
         registerPlaceholder(cm, "restart", new RestartCommand());
         registerPlaceholder(cm, "seen", new SeenCommand());
-        registerPlaceholder(cm, "send", new SendCommand());
-        registerPlaceholder(cm, "server", new ServerCommand());
-        registerPlaceholder(cm, "serverlist", new ServerListCommand());
+        registerPlaceholder(cm, "send", new SendCommand(plugin));
+        registerPlaceholder(cm, "server", new ServerCommand(plugin));
+        registerPlaceholder(cm, "serverlist", new ServerListCommand(plugin));
         registerPlaceholder(cm, "staffchat", new StaffChatCommand());
         registerPlaceholder(cm, "stats", new StatsCommand());
         registerPlaceholder(cm, "teamchat", new TeamChatCommand());
@@ -53,7 +53,7 @@ public class VelocityCommandManager {
         registerPlaceholder(cm, "top", new TopCommand());
         registerPlaceholder(cm, "unban", new UnbanCommand());
         registerPlaceholder(cm, "unmute", new UnmuteCommand());
-        registerPlaceholder(cm, "uptime", new UptimeCommand());
+        registerPlaceholder(cm, "uptime", new UptimeCommand(plugin));
         registerPlaceholder(cm, "vanish", new VanishCommand());
         registerPlaceholder(cm, "warn", new WarnCommand());
         registerPlaceholder(cm, "whois", new WhoisCommand());

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VersionCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VersionCommand.java
@@ -4,6 +4,8 @@ import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand.Invocation;
 import net.kyori.adventure.text.Component;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
 
 /**
  * Simple command to display the current plugin version on Velocity.
@@ -11,14 +13,16 @@ import net.kyori.adventure.text.Component;
 public class VersionCommand implements SimpleCommand {
 
     private final String version;
-
-    public VersionCommand(String version) {
+    private final ConfigManager configManager;
+    public VersionCommand(VelocitySystem plugin, String version) {
         this.version = version;
+        this.configManager = plugin.getConfigManager();
     }
 
     @Override
     public void execute(Invocation invocation) {
         CommandSource source = invocation.source();
-        source.sendMessage(Component.text("BungeeSystem version " + version));
+        String message = configManager.getMessage("system.version", "version", version);
+        source.sendMessage(Component.text(message));
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/AfkCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/AfkCommand.java
@@ -1,7 +1,73 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class AfkCommand extends BaseVelocityCommand {
-    public AfkCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Basic AFK command implementation for Velocity.
+ */
+public class AfkCommand implements SimpleCommand {
+    private static final Map<UUID, Boolean> afkPlayers = new HashMap<>();
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public AfkCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        if (!(source instanceof Player)) {
+            source.sendMessage(Component.text(configManager.getMessage("general.player_only")));
+            return;
+        }
+
+        Player player = (Player) source;
+        UUID uuid = player.getUniqueId();
+        boolean isAfk = !isAfk(uuid);
+        afkPlayers.put(uuid, isAfk);
+
+        if (isAfk) {
+            server.sendMessage(Component.text(
+                    configManager.getMessage("afk.player_now_afk", "player", player.getUsername())
+            ));
+        } else {
+            server.sendMessage(Component.text(
+                    configManager.getMessage("afk.player_no_longer_afk", "player", player.getUsername())
+            ));
+        }
+    }
+
+    /**
+     * Check if a player is currently AFK.
+     */
+    public static boolean isAfk(UUID uuid) {
+        return afkPlayers.getOrDefault(uuid, false);
+    }
+
+    /**
+     * Directly set a player's AFK state.
+     */
+    public static void setAfk(UUID uuid, boolean afk) {
+        afkPlayers.put(uuid, afk);
+    }
+
+    /**
+     * Clear the AFK state on disconnect.
+     */
+    public static void clearAfk(UUID uuid) {
+        afkPlayers.remove(uuid);
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/BlockBungeeCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/BlockBungeeCommand.java
@@ -1,7 +1,35 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class BlockBungeeCommand extends BaseVelocityCommand {
-    public BlockBungeeCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Demonstrates permission checks and prints the proxy version.
+ */
+public class BlockBungeeCommand implements SimpleCommand {
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public BlockBungeeCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        if (source.hasPermission("bungeesystem.allow.bungee")) {
+            String msg = configManager.getMessage("blockbungee.allowed", "version", server.getVersion());
+            source.sendMessage(Component.text(msg));
+        } else if (source.hasPermission("bungeesystem.notallowd.bungee")) {
+            source.sendMessage(Component.text(configManager.getMessage("blockbungee.not_allowed")));
+        } else {
+            source.sendMessage(Component.text(configManager.getMessage("general.no_permission")));
+        }
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/BroadcastCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/BroadcastCommand.java
@@ -1,7 +1,35 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class BroadcastCommand extends BaseVelocityCommand {
-    public BroadcastCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Broadcast a message to all players on Velocity.
+ */
+public class BroadcastCommand implements SimpleCommand {
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public BroadcastCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+        if (args.length == 0) {
+            source.sendMessage(Component.text(configManager.getMessage("broadcast.usage")));
+            return;
+        }
+        String message = String.join(" ", args);
+        String prefix = configManager.getMessage("broadcast.prefix");
+        server.sendMessage(Component.text(prefix + message));
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/FindCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/FindCommand.java
@@ -1,7 +1,42 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class FindCommand extends BaseVelocityCommand {
-    public FindCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Finds the server a player is connected to.
+ */
+public class FindCommand implements SimpleCommand {
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public FindCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+        if (args.length < 1) {
+            source.sendMessage(Component.text(configManager.getMessage("find.usage")));
+            return;
+        }
+        String playerName = args[0];
+        Player target = server.getPlayer(playerName).orElse(null);
+        if (target != null && target.getCurrentServer().isPresent()) {
+            String serverName = target.getCurrentServer().get().getServerInfo().getName();
+            String msg = configManager.getMessage("find.player_location", "player", playerName, "server", serverName);
+            source.sendMessage(Component.text(msg));
+        } else {
+            source.sendMessage(Component.text(configManager.getMessage("find.player_not_found", "player", playerName)));
+        }
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ListCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ListCommand.java
@@ -1,7 +1,37 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class ListCommand extends BaseVelocityCommand {
-    public ListCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+import java.util.stream.Collectors;
+
+/**
+ * Lists all online players on the proxy.
+ */
+public class ListCommand implements SimpleCommand {
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public ListCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String players = server.getAllPlayers().stream()
+                .map(Player::getUsername)
+                .collect(Collectors.joining(", "));
+        String msg = configManager.getMessage("list.online_players",
+                "count", String.valueOf(server.getPlayerCount()),
+                "players", players);
+        source.sendMessage(Component.text(msg));
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/MaintenanceCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/MaintenanceCommand.java
@@ -1,7 +1,122 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class MaintenanceCommand extends BaseVelocityCommand {
-    public MaintenanceCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import net.kyori.adventure.text.Component;
+
+import java.util.UUID;
+
+public class MaintenanceCommand implements SimpleCommand {
+    private static boolean maintenanceMode;
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public MaintenanceCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+        maintenanceMode = configManager.getConfig().getBoolean("maintenance.enabled", false);
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource sender = invocation.source();
+        String[] args = invocation.arguments();
+
+        if (args.length == 0) {
+            toggleMaintenance(sender);
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("on")) {
+            setMaintenance(sender, true);
+            return;
+        }
+        if (args[0].equalsIgnoreCase("off")) {
+            setMaintenance(sender, false);
+            return;
+        }
+        if (args[0].equalsIgnoreCase("whitelist") && args.length >= 3) {
+            handleWhitelist(sender, args);
+            return;
+        }
+
+        sender.sendMessage(Component.text("§eUsage: §f/maintenance [on|off]"));
+        sender.sendMessage(Component.text("§eUsage: §f/maintenance whitelist add <player>"));
+        sender.sendMessage(Component.text("§eUsage: §f/maintenance whitelist remove <player>"));
+    }
+
+    private void toggleMaintenance(CommandSource sender) {
+        maintenanceMode = !maintenanceMode;
+        configManager.getConfig().set("maintenance.enabled", maintenanceMode);
+        configManager.saveConfig();
+        if (maintenanceMode) {
+            sender.sendMessage(Component.text(configManager.getMessage("system.maintenance_enabled")));
+            kickNonWhitelisted();
+        } else {
+            sender.sendMessage(Component.text(configManager.getMessage("system.maintenance_disabled")));
+        }
+    }
+
+    private void setMaintenance(CommandSource sender, boolean enabled) {
+        maintenanceMode = enabled;
+        configManager.getConfig().set("maintenance.enabled", enabled);
+        configManager.saveConfig();
+        if (enabled) {
+            sender.sendMessage(Component.text(configManager.getMessage("system.maintenance_enabled")));
+            kickNonWhitelisted();
+        } else {
+            sender.sendMessage(Component.text(configManager.getMessage("system.maintenance_disabled")));
+        }
+    }
+
+    private void handleWhitelist(CommandSource sender, String[] args) {
+        if (args[1].equalsIgnoreCase("add") && args.length >= 3) {
+            Player target = server.getPlayer(args[2]).orElse(null);
+            if (target == null) {
+                sender.sendMessage(Component.text(configManager.getMessage("system.player_not_found", "player", args[2])));
+                return;
+            }
+            UUID uuid = target.getUniqueId();
+            configManager.addToWhitelist(uuid);
+            sender.sendMessage(Component.text(configManager.getMessage("whitelist.player_added", "player", target.getUsername())));
+            return;
+        }
+        if (args[1].equalsIgnoreCase("remove") && args.length >= 3) {
+            Player target = server.getPlayer(args[2]).orElse(null);
+            if (target == null) {
+                sender.sendMessage(Component.text(configManager.getMessage("system.player_not_found", "player", args[2])));
+                return;
+            }
+            UUID uuid = target.getUniqueId();
+            configManager.removeFromWhitelist(uuid);
+            sender.sendMessage(Component.text(configManager.getMessage("whitelist.player_removed", "player", target.getUsername())));
+            if (maintenanceMode && target.isActive()) {
+                target.disconnect(Component.text(configManager.getMessage("join.maintenance_kick") + "\n" +
+                        configManager.getMessage("join.maintenance_kick_info")));
+            }
+        }
+    }
+
+    private void kickNonWhitelisted() {
+        for (Player player : server.getAllPlayers()) {
+            if (player.hasPermission("bungeesystem.maintenance.bypass")) {
+                continue;
+            }
+            if (!configManager.isInWhitelist(player.getUniqueId())) {
+                player.disconnect(Component.text(
+                        configManager.getMessage("join.maintenance_kick") + "\n" +
+                        configManager.getMessage("join.maintenance_kick_info")
+                ));
+            }
+        }
+    }
+
+    public static boolean isMaintenanceMode() {
+        return maintenanceMode;
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/NickCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/NickCommand.java
@@ -1,7 +1,99 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class NickCommand extends BaseVelocityCommand {
-    public NickCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.Player;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Simple nickname command for Velocity.
+ */
+public class NickCommand implements SimpleCommand {
+    private final ConfigManager configManager;
+    private static final Map<UUID, String> nicknames = new HashMap<>();
+    private static final Map<String, UUID> nicknameToUUID = new HashMap<>();
+    private static final Pattern VALID_NICKNAME = Pattern.compile("^[a-zA-Z0-9_&§]{3,16}$");
+
+    public NickCommand(VelocitySystem plugin) {
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+        if (!(source instanceof Player)) {
+            source.sendMessage(Component.text(configManager.getMessage("general.player_only")));
+            return;
+        }
+        Player player = (Player) source;
+
+        if (args.length < 1) {
+            resetNickname(player);
+            return;
+        }
+        String nickname = args[0];
+
+        if (nickname.equalsIgnoreCase("off") || nickname.equalsIgnoreCase("reset")) {
+            resetNickname(player);
+            return;
+        }
+
+        if (!VALID_NICKNAME.matcher(nickname).matches()) {
+            player.sendMessage(Component.text(configManager.getMessage("nick.invalid_format")));
+            return;
+        }
+
+        if (isNicknameTaken(nickname, player.getUniqueId())) {
+            player.sendMessage(Component.text(configManager.getMessage("nick.already_taken")));
+            return;
+        }
+
+        String previousNick = nicknames.get(player.getUniqueId());
+        if (previousNick != null) {
+            nicknameToUUID.remove(previousNick.toLowerCase());
+        }
+
+        if (player.hasPermission("bungeesystem.nick.color")) {
+            nickname = net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', nickname);
+        }
+
+        nicknames.put(player.getUniqueId(), nickname);
+        nicknameToUUID.put(nickname.toLowerCase(), player.getUniqueId());
+        player.sendMessage(Component.text(configManager.getMessage("nick.changed", "nickname", nickname)));
+    }
+
+    private void resetNickname(Player player) {
+        String oldNick = nicknames.remove(player.getUniqueId());
+        if (oldNick != null) {
+            nicknameToUUID.remove(oldNick.toLowerCase());
+        }
+        player.sendMessage(Component.text(configManager.getMessage("nick.reset")));
+    }
+
+    private boolean isNicknameTaken(String nickname, UUID uuid) {
+        nickname = net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', nickname).toLowerCase();
+        UUID existing = nicknameToUUID.get(nickname);
+        return existing != null && !existing.equals(uuid);
+    }
+
+    public static UUID getPlayerFromNickname(String nickname) {
+        return nicknameToUUID.get(nickname.toLowerCase());
+    }
+
+    public static String getNickname(UUID uuid) {
+        return nicknames.get(uuid);
+    }
+
+    public static boolean hasNickname(UUID uuid) {
+        return nicknames.containsKey(uuid);
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/PingCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/PingCommand.java
@@ -5,19 +5,28 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand.Invocation;
 import com.velocitypowered.api.proxy.Player;
 import net.kyori.adventure.text.Component;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
 
 /**
  * Simple ping command for Velocity.
  */
 public class PingCommand implements SimpleCommand {
+    private final ConfigManager configManager;
+
+    public PingCommand(VelocitySystem plugin) {
+        this.configManager = plugin.getConfigManager();
+    }
+
     @Override
     public void execute(Invocation invocation) {
         CommandSource source = invocation.source();
         if (source instanceof Player) {
             Player player = (Player) source;
-            player.sendMessage(Component.text("Pong: " + player.getPing() + "ms"));
+            String msg = configManager.getMessage("system.ping", "ping", String.valueOf(player.getPing()));
+            player.sendMessage(Component.text(msg));
         } else {
-            source.sendMessage(Component.text("This command can only be used by players."));
+            source.sendMessage(Component.text(configManager.getMessage("general.player_only")));
         }
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ReloadConfigCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ReloadConfigCommand.java
@@ -1,7 +1,31 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class ReloadConfigCommand extends BaseVelocityCommand {
-    public ReloadConfigCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import net.kyori.adventure.text.Component;
+
+import java.io.IOException;
+
+public class ReloadConfigCommand implements SimpleCommand {
+    private final ConfigManager configManager;
+
+    public ReloadConfigCommand(VelocitySystem plugin) {
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        try {
+            configManager.reloadAll();
+            source.sendMessage(Component.text(configManager.getMessage("system.reload_success")));
+        } catch (IOException e) {
+            source.sendMessage(Component.text(
+                    configManager.getMessage("system.reload_failed", "error", e.getMessage())
+            ));
+        }
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/SendCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/SendCommand.java
@@ -1,7 +1,47 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class SendCommand extends BaseVelocityCommand {
-    public SendCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Sends a player to a specified server.
+ */
+public class SendCommand implements SimpleCommand {
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public SendCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String[] args = invocation.arguments();
+        if (args.length < 2) {
+            source.sendMessage(Component.text(configManager.getMessage("send.usage")));
+            return;
+        }
+        String targetName = args[0];
+        String serverName = args[1];
+
+        Player target = server.getPlayer(targetName).orElse(null);
+        RegisteredServer registeredServer = server.getServer(serverName).orElse(null);
+
+        if (target != null && registeredServer != null) {
+            target.createConnectionRequest(registeredServer).fireAndForget();
+            String msg = configManager.getMessage("send.success", "player", targetName, "server", serverName);
+            source.sendMessage(Component.text(msg));
+        } else {
+            source.sendMessage(Component.text(configManager.getMessage("send.player_or_server_not_found")));
+        }
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ServerCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ServerCommand.java
@@ -1,7 +1,34 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class ServerCommand extends BaseVelocityCommand {
-    public ServerCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+import java.util.stream.Collectors;
+
+/**
+ * Lists all known servers from the proxy configuration.
+ */
+public class ServerCommand implements SimpleCommand {
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public ServerCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String servers = server.getAllServers().stream()
+                .map(s -> s.getServerInfo().getName())
+                .collect(Collectors.joining(", "));
+        String msg = configManager.getMessage("server.list", "servers", servers);
+        source.sendMessage(Component.text(msg));
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ServerListCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ServerListCommand.java
@@ -1,7 +1,35 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class ServerListCommand extends BaseVelocityCommand {
-    public ServerListCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import com.velocitypowered.api.proxy.ProxyServer;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+import java.util.stream.Collectors;
+
+/**
+ * Displays all online servers.
+ */
+public class ServerListCommand implements SimpleCommand {
+    private final ProxyServer server;
+    private final ConfigManager configManager;
+
+    public ServerListCommand(VelocitySystem plugin) {
+        this.server = plugin.getServer();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        String servers = server.getAllServers().stream()
+                .map(s -> s.getServerInfo().getName())
+                .collect(Collectors.joining(", "));
+        String msg = configManager.getMessage("serverlist.list", "servers", server 
+                .getAllServers().isEmpty() ? "" : servers);
+        source.sendMessage(Component.text(msg));
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/UptimeCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/UptimeCommand.java
@@ -1,7 +1,29 @@
 package me.dergamer09.bungeesystem.velocity.commands;
 
-public class UptimeCommand extends BaseVelocityCommand {
-    public UptimeCommand() {
-        super("This command is not yet implemented on Velocity.");
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.SimpleCommand.Invocation;
+import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Displays the proxy uptime in seconds.
+ */
+public class UptimeCommand implements SimpleCommand {
+    private final long startTime;
+    private final ConfigManager configManager;
+
+    public UptimeCommand(VelocitySystem plugin) {
+        this.startTime = System.currentTimeMillis();
+        this.configManager = plugin.getConfigManager();
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        CommandSource source = invocation.source();
+        long uptime = (System.currentTimeMillis() - startTime) / 1000;
+        String msg = configManager.getMessage("uptime.server_uptime", "seconds", String.valueOf(uptime));
+        source.sendMessage(Component.text(msg));
     }
 }

--- a/src/main/resources/messages_de.yml
+++ b/src/main/resources/messages_de.yml
@@ -16,6 +16,8 @@ system:
   server_not_found: "&cServer &e%server% &cnicht gefunden."
   server_restart_success: "&aStarte Server &e%server% &aneu..."
   server_restart_failed: "&cKonnte Server &e%server% &cnicht neu starten: &7%error%"
+  version: "&aBungeeSystem Version &e%version%"
+  ping: "&aPong: &e%ping%ms"
   
 whitelist:
   player_added: "&aPlayer &e%player% &ahas been added to the maintenance whitelist."
@@ -115,6 +117,43 @@ teamchat:
 staffchat:
   usage: "&eUsage: &f/staffchat <message> or /sc <message>"
   no_recipients: "&cNo staff members are online to receive your message."
+
+# Broadcast command messages
+broadcast:
+  usage: "&eBenutzung: &f/broadcast <Nachricht>"
+  prefix: "&6[Broadcast] &f"
+
+# Uptime command messages
+uptime:
+  server_uptime: "&aServer-Laufzeit: &e%seconds% Sekunden"
+
+# List command messages
+list:
+  online_players: "&aAktuell online (%count%): &e%players%"
+
+# Server command messages
+server:
+  list: "&aVerf\u00fcgbare Server: &e%servers%"
+
+serverlist:
+  list: "&aOnline-Server: &e%servers%"
+
+# Send command messages
+send:
+  usage: "&eVerwendung: &f/send <Spieler> <Server>"
+  success: "&a%player% wurde zu &e%server% &ageschickt"
+  player_or_server_not_found: "&cSpieler oder Server nicht gefunden."
+
+# Find command messages
+find:
+  usage: "&eVerwendung: &f/find <Spieler>"
+  player_location: "&e%player% &aist momentan auf &e%server%"
+  player_not_found: "&cSpieler %player% nicht gefunden oder offline."
+
+# BlockBungee command messages
+blockbungee:
+  allowed: "&aDu hast die Berechtigung. Proxy-Version: &e%version%"
+  not_allowed: "&cEntschuldigung, dieser Befehl ist nicht erlaubt."
 
 # Global Chat command messages
 globalchat:

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -16,6 +16,8 @@ system:
   server_not_found: "&cServer &e%server% &cnot found."
   server_restart_success: "&aRestarting server &e%server%&a..."
   server_restart_failed: "&cFailed to restart &e%server%&c: &7%error%"
+  version: "&aBungeeSystem version &e%version%"
+  ping: "&aPong: &e%ping%ms"
   
 whitelist:
   player_added: "&aPlayer &e%player% &ahas been added to the maintenance whitelist."
@@ -115,6 +117,43 @@ teamchat:
 staffchat:
   usage: "&eUsage: &f/staffchat <message> or /sc <message>"
   no_recipients: "&cNo staff members are online to receive your message."
+
+# Broadcast command messages
+broadcast:
+  usage: "&eUsage: &f/broadcast <message>"
+  prefix: "&6[Broadcast] &f"
+
+# Uptime command messages
+uptime:
+  server_uptime: "&aServer Uptime: &e%seconds% seconds"
+
+# List command messages
+list:
+  online_players: "&aCurrently online (%count%): &e%players%"
+
+# Server command messages
+server:
+  list: "&aAvailable Servers: &e%servers%"
+
+serverlist:
+  list: "&aOnline Servers: &e%servers%"
+
+# Send command messages
+send:
+  usage: "&eUsage: &f/send <player> <server>"
+  success: "&aSent &e%player% &ato &e%server%"
+  player_or_server_not_found: "&cPlayer or server not found."
+
+# Find command messages
+find:
+  usage: "&eUsage: &f/find <player>"
+  player_location: "&e%player% &ais currently on &e%server%"
+  player_not_found: "&cPlayer %player% not found or offline."
+
+# BlockBungee command messages
+blockbungee:
+  allowed: "&aYou have permission. Proxy version: &e%version%"
+  not_allowed: "&cSorry, this command is not allowed."
 
 # Global Chat command messages
 globalchat:


### PR DESCRIPTION
## Summary
- implement Velocity versions of list, server, serverlist, send, find, and blockbungee commands
- add message keys for new Velocity commands in English and German configs
- update Velocity command manager registration

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d6145faf4832e913ff7282c94239d