### PR TITLE
Fix Velocity command registration

### DIFF
--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/VelocityCommandManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/VelocityCommandManager.java
@@ -1,6 +1,7 @@
 package me.dergamer09.bungeesystem.velocity.Managers;
 
 import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.command.SimpleCommand;
 import me.dergamer09.bungeesystem.velocity.VelocitySystem;
 import me.dergamer09.bungeesystem.velocity.VersionCommand;
 import me.dergamer09.bungeesystem.velocity.commands.*;
@@ -59,7 +60,7 @@ public class VelocityCommandManager {
         registerPlaceholder(cm, "whois", new WhoisCommand());
     }
 
-    private void registerPlaceholder(CommandManager cm, String name, BaseVelocityCommand command) {
+    private void registerPlaceholder(CommandManager cm, String name, SimpleCommand command) {
         cm.register(cm.metaBuilder(name).plugin(plugin).build(), command);
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/BlockBungeeCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/BlockBungeeCommand.java
@@ -24,7 +24,11 @@ public class BlockBungeeCommand implements SimpleCommand {
     public void execute(Invocation invocation) {
         CommandSource source = invocation.source();
         if (source.hasPermission("bungeesystem.allow.bungee")) {
-            String msg = configManager.getMessage("blockbungee.allowed", "version", server.getVersion());
+            String msg = configManager.getMessage(
+                    "blockbungee.allowed",
+                    "version",
+                    server.getVersion().getVersion()
+            );
             source.sendMessage(Component.text(msg));
         } else if (source.hasPermission("bungeesystem.notallowd.bungee")) {
             source.sendMessage(Component.text(configManager.getMessage("blockbungee.not_allowed")));


### PR DESCRIPTION
## Summary
- fix parameter type for `VelocityCommandManager.registerPlaceholder`
- convert `ProxyVersion` to text before formatting in `BlockBungeeCommand`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d66e45d58832ebaa416b154fb546d