### PR TITLE
Fix ChatColor usage in Velocity commands

### DIFF
--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ConfigManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ConfigManager.java
@@ -1,10 +1,11 @@
 package me.dergamer09.bungeesystem.velocity.Managers;
 
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
 import org.slf4j.Logger;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,7 +95,7 @@ public class ConfigManager {
         if (message == null) {
             return "§cMessage not found: " + path;
         }
-        return ChatColor.translateAlternateColorCodes('&', message);
+        return translateColorCodes(message);
     }
 
     public String getMessage(String path, String... replacements) {
@@ -108,6 +109,11 @@ public class ConfigManager {
         return message;
     }
 
+    public Component getMessageComponent(String path, String... replacements) {
+        String msg = getMessage(path, replacements);
+        return LegacyComponentSerializer.legacySection().deserialize(msg);
+    }
+
     public List<UUID> getMaintenanceWhitelist() {
         List<String> list = config.getStringList("maintenance.whitelist");
         List<UUID> uuids = new ArrayList<>();
@@ -118,6 +124,31 @@ public class ConfigManager {
             }
         }
         return uuids;
+    }
+
+    public static String translateColorCodes(String text) {
+        return translateColorCodes('&', text);
+    }
+
+    public static String translateColorCodes(char altColorChar, String text) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == altColorChar && i + 1 < text.length()) {
+                char next = text.charAt(i + 1);
+                if (isColorCode(next)) {
+                    builder.append('\u00A7').append(Character.toLowerCase(next));
+                    i++;
+                    continue;
+                }
+            }
+            builder.append(c);
+        }
+        return builder.toString();
+    }
+
+    private static boolean isColorCode(char c) {
+        return "0123456789AaBbCcDdEeFfKkLlMmNnOoRr".indexOf(c) >= 0;
     }
 
     public void saveConfig() {

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/NickCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/NickCommand.java
@@ -6,7 +6,6 @@ import com.velocitypowered.api.command.SimpleCommand.Invocation;
 import com.velocitypowered.api.proxy.Player;
 import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
 import me.dergamer09.bungeesystem.velocity.VelocitySystem;
-import net.kyori.adventure.text.Component;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +30,7 @@ public class NickCommand implements SimpleCommand {
         CommandSource source = invocation.source();
         String[] args = invocation.arguments();
         if (!(source instanceof Player)) {
-            source.sendMessage(Component.text(configManager.getMessage("general.player_only")));
+            source.sendMessage(configManager.getMessageComponent("general.player_only"));
             return;
         }
         Player player = (Player) source;
@@ -48,12 +47,12 @@ public class NickCommand implements SimpleCommand {
         }
 
         if (!VALID_NICKNAME.matcher(nickname).matches()) {
-            player.sendMessage(Component.text(configManager.getMessage("nick.invalid_format")));
+            player.sendMessage(configManager.getMessageComponent("nick.invalid_format"));
             return;
         }
 
         if (isNicknameTaken(nickname, player.getUniqueId())) {
-            player.sendMessage(Component.text(configManager.getMessage("nick.already_taken")));
+            player.sendMessage(configManager.getMessageComponent("nick.already_taken"));
             return;
         }
 
@@ -63,12 +62,12 @@ public class NickCommand implements SimpleCommand {
         }
 
         if (player.hasPermission("bungeesystem.nick.color")) {
-            nickname = net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', nickname);
+            nickname = ConfigManager.translateColorCodes(nickname);
         }
 
         nicknames.put(player.getUniqueId(), nickname);
         nicknameToUUID.put(nickname.toLowerCase(), player.getUniqueId());
-        player.sendMessage(Component.text(configManager.getMessage("nick.changed", "nickname", nickname)));
+        player.sendMessage(configManager.getMessageComponent("nick.changed", "nickname", nickname));
     }
 
     private void resetNickname(Player player) {
@@ -76,11 +75,11 @@ public class NickCommand implements SimpleCommand {
         if (oldNick != null) {
             nicknameToUUID.remove(oldNick.toLowerCase());
         }
-        player.sendMessage(Component.text(configManager.getMessage("nick.reset")));
+        player.sendMessage(configManager.getMessageComponent("nick.reset"));
     }
 
     private boolean isNicknameTaken(String nickname, UUID uuid) {
-        nickname = net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', nickname).toLowerCase();
+        nickname = ConfigManager.translateColorCodes(nickname).toLowerCase();
         UUID existing = nicknameToUUID.get(nickname);
         return existing != null && !existing.equals(uuid);
     }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/PingCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/PingCommand.java
@@ -23,10 +23,10 @@ public class PingCommand implements SimpleCommand {
         CommandSource source = invocation.source();
         if (source instanceof Player) {
             Player player = (Player) source;
-            String msg = configManager.getMessage("system.ping", "ping", String.valueOf(player.getPing()));
-            player.sendMessage(Component.text(msg));
+            Component msg = configManager.getMessageComponent("system.ping", "ping", String.valueOf(player.getPing()));
+            player.sendMessage(msg);
         } else {
-            source.sendMessage(Component.text(configManager.getMessage("general.player_only")));
+            source.sendMessage(configManager.getMessageComponent("general.player_only"));
         }
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ReloadConfigCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/ReloadConfigCommand.java
@@ -5,7 +5,6 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.SimpleCommand.Invocation;
 import me.dergamer09.bungeesystem.velocity.VelocitySystem;
 import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
-import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
@@ -21,10 +20,10 @@ public class ReloadConfigCommand implements SimpleCommand {
         CommandSource source = invocation.source();
         try {
             configManager.reloadAll();
-            source.sendMessage(Component.text(configManager.getMessage("system.reload_success")));
+            source.sendMessage(configManager.getMessageComponent("system.reload_success"));
         } catch (IOException e) {
-            source.sendMessage(Component.text(
-                    configManager.getMessage("system.reload_failed", "error", e.getMessage())
+            source.sendMessage(configManager.getMessageComponent(
+                    "system.reload_failed", "error", e.getMessage()
             ));
         }
     }


### PR DESCRIPTION
## Summary
- add custom color translator for Velocity
- provide helper to get pre-colored components
- use components in Ping, Nick, and ReloadConfig commands

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6807d4c0832eb2e2a38114de747d