### PR TITLE
Add bStats metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Das Plugin verwendet ein Manager-System für bessere Organisation:
 Die Konfigurationsdatei befindet sich unter `plugins/BungeeSystem/config.yml` und erlaubt die Anpassung von Nachrichten, Berechtigungen und weiteren Funktionen.
 Trage dort deine Discord **webhookUrl** ein, damit neue Reports automatisch an deinen Discord-Channel gemeldet werden. Über **reportWebhookFormat** kannst du das Nachrichtenformat festlegen. Änderungen an der URL oder dem Format werden erst nach `/reloadconfig` wirksam.
 
+## bStats
+Dieses Plugin verwendet [bStats](https://bstats.org/), um anonyme Nutzungsstatistiken zu sammeln. Über die globale bStats-Konfigurationsdatei kann das Tracking jederzeit deaktiviert werden.
+
 ## Lizenz
 Dieses Plugin wird unter der **MIT-Lizenz** veröffentlicht. Mehr Details findest du in der `LICENSE`-Datei.
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,16 @@
           <version>3.1.1</version>
           <scope>provided</scope>
       </dependency>
+      <dependency>
+          <groupId>org.bstats</groupId>
+          <artifactId>bstats-bungeecord</artifactId>
+          <version>3.0.2</version>
+      </dependency>
+      <dependency>
+          <groupId>org.bstats</groupId>
+          <artifactId>bstats-velocity</artifactId>
+          <version>3.0.2</version>
+      </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/me/dergamer09/bungeesystem/BungeeSystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/BungeeSystem.java
@@ -1,6 +1,7 @@
 package me.dergamer09.bungeesystem;
 
 import me.dergamer09.bungeesystem.Managers.*;
+import org.bstats.bungeecord.Metrics;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.config.Configuration;
 
@@ -31,6 +32,10 @@ public final class BungeeSystem extends Plugin {
     private StatsManager statsManager;
     private ChatManager chatManager;
     private PunishmentManager punishmentManager;
+
+    // bStats metrics
+    private Metrics metrics;
+    private static final int BSTATS_PLUGIN_ID = 26442;
     
     // Plugin data
     private Configuration config;
@@ -47,6 +52,9 @@ public final class BungeeSystem extends Plugin {
         
         // Initialize managers
         initializeManagers();
+
+        // Start bStats metrics
+        metrics = new Metrics(this, BSTATS_PLUGIN_ID);
         
         // Initialize database with detailed diagnostics and retry
         if (!initializeDatabase()) {

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
@@ -10,6 +10,7 @@ import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 import java.nio.file.Path;
+import org.bstats.velocity.Metrics;
 
 import me.dergamer09.bungeesystem.velocity.Managers.VelocityCommandManager;
 import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
@@ -27,16 +28,20 @@ public class VelocitySystem {
     private final ProxyServer server;
     private final Logger logger;
     private final Path dataDirectory;
+    private final Metrics.Factory metricsFactory;
 
     private ConfigManager configManager;
     private VelocityCommandManager commandManager;
     private ListenerManager listenerManager;
+    private Metrics metrics;
+    private static final int BSTATS_PLUGIN_ID = 26442;
 
     @Inject
-    public VelocitySystem(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
+    public VelocitySystem(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory, Metrics.Factory metricsFactory) {
         this.server = server;
         this.logger = logger;
         this.dataDirectory = dataDirectory;
+        this.metricsFactory = metricsFactory;
     }
 
     public ProxyServer getServer() { return server; }
@@ -45,6 +50,7 @@ public class VelocitySystem {
     @Subscribe
     public void onProxyInit(ProxyInitializeEvent event) {
         logger.info("BungeeSystem loaded (Velocity compatibility mode).");
+        metrics = metricsFactory.make(this, BSTATS_PLUGIN_ID);
         configManager = new ConfigManager(logger, getClass().getClassLoader(), dataDirectory);
         commandManager = new VelocityCommandManager(this);
         listenerManager = new ListenerManager(this, logger);


### PR DESCRIPTION
## Summary
- integrate bStats to track anonymous plugin usage
- inject metrics into Bungee and Velocity entry points
- add bStats dependencies to the build
- mention bStats usage in README

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee962a1e4832ea0debf7a600212ec