### PR TITLE
Implement MOTD manager

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -28,6 +28,11 @@ errorMessageColor: "&c"
 webhookUrl: "https://your-discord-webhook-url.com" #ReportSystem
 reportWebhookFormat: "New report #%id% against %player% by %reporter% on %server%: %reason%"
 
+# Server MOTD configuration
+motd:
+  normal: "Welcome to the BungeeSystem Server!"
+  maintenance: "&c\uD83D\uDEA7 Maintenance Mode - Server is currently under maintenance! \uD83D\uDEA7"
+
 # Maintenance mode configuration
 maintenance:
   enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,14 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.bstats</pattern>
+                  <shadedPattern>me.dergamer09.bungeesystem.shaded.bstats</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/me/dergamer09/bungeesystem/BungeeSystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/BungeeSystem.java
@@ -32,6 +32,7 @@ public final class BungeeSystem extends Plugin {
     private StatsManager statsManager;
     private ChatManager chatManager;
     private PunishmentManager punishmentManager;
+    private MotdManager motdManager;
 
     // bStats metrics
     private Metrics metrics;
@@ -113,6 +114,7 @@ public final class BungeeSystem extends Plugin {
         updateManager = new UpdateManager(this, currentVersion);
         startupManager = new StartupManager(this, currentVersion);
         chatManager = new ChatManager(this);
+        motdManager = new MotdManager(this);
         
         // Set webhook URL from config
         webhookUrl = config.getString("webhookUrl", "");
@@ -216,6 +218,13 @@ public final class BungeeSystem extends Plugin {
      */
     public ChatManager getChatManager() {
         return chatManager;
+    }
+
+    /**
+     * Get the MOTD manager
+     */
+    public MotdManager getMotdManager() {
+        return motdManager;
     }
     
     /**

--- a/src/main/java/me/dergamer09/bungeesystem/Managers/ListenerManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/Managers/ListenerManager.java
@@ -29,7 +29,7 @@ public class ListenerManager {
         PluginManager pm = plugin.getProxy().getPluginManager();
         
         // Register listeners
-        pm.registerListener(plugin, new MotdListener());
+        pm.registerListener(plugin, new MotdListener(plugin));
         pm.registerListener(plugin, new PlayerEventListener());
         pm.registerListener(plugin, new StatsListener(plugin));
         pm.registerListener(plugin, new ChatListener(plugin));
@@ -48,5 +48,4 @@ public class ListenerManager {
             1L, 
             TimeUnit.SECONDS
         );
-    }
-} 
+    }} 

--- a/src/main/java/me/dergamer09/bungeesystem/Managers/MotdManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/Managers/MotdManager.java
@@ -1,0 +1,39 @@
+package me.dergamer09.bungeesystem.Managers;
+
+import me.dergamer09.bungeesystem.BungeeSystem;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.config.Configuration;
+
+/**
+ * Handles MOTD messages for BungeeCord.
+ */
+public class MotdManager {
+    private final BungeeSystem plugin;
+    private String normalMotd;
+    private String maintenanceMotd;
+
+    public MotdManager(BungeeSystem plugin) {
+        this.plugin = plugin;
+        loadFromConfig();
+    }
+
+    /** Reload MOTD values from config. */
+    public void loadFromConfig() {
+        Configuration cfg = plugin.getConfig();
+        normalMotd = ChatColor.translateAlternateColorCodes('&',
+                cfg.getString("motd.normal", "Welcome to the BungeeSystem Server!"));
+        maintenanceMotd = ChatColor.translateAlternateColorCodes('&',
+                cfg.getString("motd.maintenance",
+                        "&c\uD83D\uDEA7 Maintenance Mode - Server is currently under maintenance! \uD83D\uDEA7"));
+    }
+
+    /**
+     * Get the MOTD depending on maintenance mode.
+     *
+     * @param maintenance whether maintenance mode is active
+     * @return MOTD string
+     */
+    public String getMotd(boolean maintenance) {
+        return maintenance ? maintenanceMotd : normalMotd;
+    }
+}

--- a/src/main/java/me/dergamer09/bungeesystem/listeners/MotdListener.java
+++ b/src/main/java/me/dergamer09/bungeesystem/listeners/MotdListener.java
@@ -1,7 +1,8 @@
 package me.dergamer09.bungeesystem.listeners;
 
+import me.dergamer09.bungeesystem.BungeeSystem;
+import me.dergamer09.bungeesystem.Managers.MotdManager;
 import me.dergamer09.bungeesystem.commands.MaintenanceCommand;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.event.ProxyPingEvent;
@@ -10,15 +11,17 @@ import net.md_5.bungee.event.EventHandler;
 
 // MOTD Listener
 public class MotdListener implements Listener {
+    private final BungeeSystem plugin;
+
+    public MotdListener(BungeeSystem plugin) {
+        this.plugin = plugin;
+    }
     @EventHandler
     public void onProxyPing(ProxyPingEvent event) {
         ServerPing response = event.getResponse();
-
-        if (MaintenanceCommand.isMaintenanceMode()) {
-            response.setDescriptionComponent(new TextComponent(ChatColor.RED + "🚧 Maintenance Mode - Server is currently under maintenance! 🚧"));
-        } else {
-            response.setDescriptionComponent(new TextComponent(ChatColor.GREEN + "Welcome to the BungeeSystem Server!"));
-        }
+        MotdManager manager = plugin.getMotdManager();
+        String motd = manager.getMotd(MaintenanceCommand.isMaintenanceMode());
+        response.setDescriptionComponent(new TextComponent(motd));
     }
 }
 

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ListenerManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ListenerManager.java
@@ -19,6 +19,7 @@ public class ListenerManager {
 
     public void registerListeners() {
         plugin.getServer().getEventManager().register(plugin, this);
+        plugin.getServer().getEventManager().register(plugin, new me.dergamer09.bungeesystem.velocity.listeners.MotdListener(plugin));
     }
 
     // Example listener for disconnects

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/MotdManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/MotdManager.java
@@ -1,0 +1,37 @@
+package me.dergamer09.bungeesystem.velocity.Managers;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.config.Configuration;
+
+/**
+ * Handles MOTD messages for Velocity.
+ */
+public class MotdManager {
+    private final ConfigManager configManager;
+    private String normalMotd;
+    private String maintenanceMotd;
+
+    public MotdManager(ConfigManager configManager) {
+        this.configManager = configManager;
+        loadFromConfig();
+    }
+
+    /** Reload MOTD values from config. */
+    public void loadFromConfig() {
+        Configuration cfg = configManager.getConfig();
+        normalMotd = ConfigManager.translateColorCodes(cfg.getString("motd.normal", "Welcome to the BungeeSystem Server!"));
+        maintenanceMotd = ConfigManager.translateColorCodes(
+                cfg.getString("motd.maintenance",
+                        "&c\uD83D\uDEA7 Maintenance Mode - Server is currently under maintenance! \uD83D\uDEA7"));
+    }
+
+    /**
+     * Get the MOTD depending on maintenance mode.
+     *
+     * @param maintenance whether maintenance mode is active
+     * @return MOTD string
+     */
+    public String getMotd(boolean maintenance) {
+        return maintenance ? maintenanceMotd : normalMotd;
+    }
+}

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
@@ -15,6 +15,7 @@ import org.bstats.velocity.Metrics;
 import me.dergamer09.bungeesystem.velocity.Managers.VelocityCommandManager;
 import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
 import me.dergamer09.bungeesystem.velocity.Managers.ListenerManager;
+import me.dergamer09.bungeesystem.velocity.Managers.MotdManager;
 import me.dergamer09.bungeesystem.velocity.Runnables.OnlineTimeUpdater;
 
 /**
@@ -33,8 +34,10 @@ public class VelocitySystem {
     private ConfigManager configManager;
     private VelocityCommandManager commandManager;
     private ListenerManager listenerManager;
+    private MotdManager motdManager;
     private Metrics metrics;
-    private static final int BSTATS_PLUGIN_ID = 26442;
+    // Use the dedicated bStats plugin ID for Velocity
+    private static final int BSTATS_PLUGIN_ID = 26443;
 
     @Inject
     public VelocitySystem(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory, Metrics.Factory metricsFactory) {
@@ -52,6 +55,7 @@ public class VelocitySystem {
         logger.info("BungeeSystem loaded (Velocity compatibility mode).");
         metrics = metricsFactory.make(this, BSTATS_PLUGIN_ID);
         configManager = new ConfigManager(logger, getClass().getClassLoader(), dataDirectory);
+        motdManager = new MotdManager(configManager);
         commandManager = new VelocityCommandManager(this);
         listenerManager = new ListenerManager(this, logger);
 
@@ -69,4 +73,5 @@ public class VelocitySystem {
     }
 
     public ConfigManager getConfigManager() { return configManager; }
+    public MotdManager getMotdManager() { return motdManager; }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/listeners/MotdListener.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/listeners/MotdListener.java
@@ -1,0 +1,29 @@
+package me.dergamer09.bungeesystem.velocity.listeners;
+
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyPingEvent;
+import com.velocitypowered.api.proxy.server.ServerPing;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import me.dergamer09.bungeesystem.velocity.Managers.MotdManager;
+import me.dergamer09.bungeesystem.velocity.commands.MaintenanceCommand;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Listens for proxy ping events to set the MOTD.
+ */
+public class MotdListener {
+    private final VelocitySystem plugin;
+
+    public MotdListener(VelocitySystem plugin) {
+        this.plugin = plugin;
+    }
+
+    @Subscribe
+    public void onProxyPing(ProxyPingEvent event) {
+        MotdManager manager = plugin.getMotdManager();
+        String motd = manager.getMotd(MaintenanceCommand.isMaintenanceMode());
+        ServerPing ping = event.getPing();
+        ServerPing.Builder builder = ping.asBuilder().description(Component.text(motd));
+        event.setPing(builder.build());
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,11 @@ errorMessageColor: "&c"
 webhookUrl: "https://your-discord-webhook-url.com" #ReportSystem
 reportWebhookFormat: "New report #%id% against %player% by %reporter% on %server%: %reason%"
 
+# Server MOTD configuration
+motd:
+  normal: "Welcome to the BungeeSystem Server!"
+  maintenance: "&c\uD83D\uDEA7 Maintenance Mode - Server is currently under maintenance! \uD83D\uDEA7"
+
 # Maintenance mode configuration
 maintenance:
   enabled: false


### PR DESCRIPTION
## Summary
- configure bStats shading
- add MOTD configuration
- add MOTD manager for BungeeCord and Velocity
- register new MOTD listeners
- integrate MOTD with maintenance command
- fix bStats plugin ID for Velocity

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_686eebae2f40832ea07064ad2daebf6d