### PR TITLE
Implement server connection and maintenance listing features

### DIFF
--- a/src/main/java/me/dergamer09/bungeesystem/commands/MaintenanceCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/commands/MaintenanceCommand.java
@@ -47,6 +47,20 @@ public class MaintenanceCommand extends Command {
             return;
         }
 
+        if (args.length >= 2 && args[0].equalsIgnoreCase("whitelist") && args[1].equalsIgnoreCase("list")) {
+            StringBuilder list = new StringBuilder("§aWhitelisted players: §e");
+            for (UUID uuid : configManager.getMaintenanceWhitelist()) {
+                ProxiedPlayer p = ProxyServer.getInstance().getPlayer(uuid);
+                String name = (p != null) ? p.getName() : uuid.toString();
+                list.append(name).append(", ");
+            }
+            if (list.lastIndexOf(", ") == list.length() - 2) {
+                list.setLength(list.length() - 2);
+            }
+            sender.sendMessage(new TextComponent(list.toString()));
+            return;
+        }
+
         if (args.length >= 1) {
             if (args[0].equalsIgnoreCase("on")) {
                 maintenanceMode = true;
@@ -106,6 +120,7 @@ public class MaintenanceCommand extends Command {
         sender.sendMessage(new TextComponent("§eUsage: §f/maintenance [on|off]"));
         sender.sendMessage(new TextComponent("§eUsage: §f/maintenance whitelist add <player>"));
         sender.sendMessage(new TextComponent("§eUsage: §f/maintenance whitelist remove <player>"));
+        sender.sendMessage(new TextComponent("§eUsage: §f/maintenance whitelist list"));
     }
 
     private void kickNonWhitelistedPlayers() {

--- a/src/main/java/me/dergamer09/bungeesystem/commands/SendCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/commands/SendCommand.java
@@ -15,6 +15,23 @@ public class SendCommand extends Command {
 
     @Override
     public void execute(CommandSender sender, String[] args) {
+        if (args.length == 1) {
+            // /send <server> - send the command sender to the server
+            if (!(sender instanceof ProxiedPlayer)) {
+                sender.sendMessage(ChatColor.RED + "This command can only be used by players!");
+                return;
+            }
+
+            ServerInfo server = BungeeSystem.getInstance().getProxy().getServerInfo(args[0]);
+            if (server != null) {
+                ((ProxiedPlayer) sender).connect(server);
+                sender.sendMessage(ChatColor.GREEN + "Connecting you to " + ChatColor.YELLOW + server.getName() + ChatColor.GREEN + "...");
+            } else {
+                sender.sendMessage(ChatColor.RED + "Server not found!");
+            }
+            return;
+        }
+
         if (args.length < 2) {
             sender.sendMessage(ChatColor.RED + "Usage: /send <player> <server>");
             return;

--- a/src/main/java/me/dergamer09/bungeesystem/commands/ServerCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/commands/ServerCommand.java
@@ -4,24 +4,54 @@ import me.dergamer09.bungeesystem.BungeeSystem;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 
 import java.util.Map;
 
+/**
+ * Handles the /server command.
+ *
+ * <p>/server list</p> or <p>/server</p> lists all available servers.
+ * <p>/server &lt;name&gt;</p> connects the executing player to the specified server.
+ */
 public class ServerCommand extends Command {
 
     public ServerCommand() {
-        super("servers", "bungeesystem.servers");
+        super("server", "bungeesystem.servers", "servers");
     }
 
     @Override
     public void execute(CommandSender sender, String[] args) {
-        StringBuilder servers = new StringBuilder(ChatColor.AQUA + "Available Servers: ");
         Map<String, ServerInfo> serverMap = BungeeSystem.getInstance().getProxy().getServers();
 
-        for (String server : serverMap.keySet()) {
-            servers.append(ChatColor.YELLOW).append(server).append(ChatColor.GRAY).append(", ");
+        // List servers when no argument or "list" is provided
+        if (args.length == 0 || (args.length == 1 && args[0].equalsIgnoreCase("list"))) {
+            StringBuilder servers = new StringBuilder(ChatColor.AQUA + "Available Servers: ");
+            for (String server : serverMap.keySet()) {
+                servers.append(ChatColor.YELLOW).append(server).append(ChatColor.GRAY).append(", ");
+            }
+            if (servers.lastIndexOf(", ") == servers.length() - 2) {
+                servers.setLength(servers.length() - 2);
+            }
+            sender.sendMessage(servers.toString());
+            return;
         }
-        sender.sendMessage(servers.toString());
+
+        // Connect sender to target server
+        if (!(sender instanceof ProxiedPlayer)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players!");
+            return;
+        }
+
+        String serverName = args[0];
+        ServerInfo server = serverMap.get(serverName);
+
+        if (server != null) {
+            ((ProxiedPlayer) sender).connect(server);
+            sender.sendMessage(ChatColor.GREEN + "Connecting you to " + ChatColor.YELLOW + serverName + ChatColor.GREEN + "...");
+        } else {
+            sender.sendMessage(ChatColor.RED + "Server not found!");
+        }
     }
 }

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -12,6 +12,8 @@ system:
   reload_failed: "&cFailed to reload configuration: &7%error%"
   maintenance_enabled: "&aServer maintenance mode has been &eenabled&a. Only whitelisted players can join."
   maintenance_disabled: "&aServer maintenance mode has been &edisabled&a."
+  maintenance_status_on: "&aMaintenance mode is currently &eenabled&a."
+  maintenance_status_off: "&aMaintenance mode is currently &cdisabled&a."
   player_not_found: "&cPlayer &e%player% &cnot found."
   server_not_found: "&cServer &e%server% &cnot found."
   server_restart_success: "&aRestarting server &e%server%&a..."


### PR DESCRIPTION
## Summary
- enhance `/server` command to allow listing servers or connecting to one
- extend `/send` to work as self-send when only a server is specified
- add `/maintenance whitelist list` and help text
- support maintenance status messages in English messages file

## Testing
- `mvn package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d745f08b8832e9611d7cbedca0eb9