### PR TITLE
Implement DB-backed maintenance whitelist

### DIFF
--- a/src/main/java/me/dergamer09/bungeesystem/Managers/ConfigManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/Managers/ConfigManager.java
@@ -127,18 +127,7 @@ public class ConfigManager {
     }
 
     public List<UUID> getMaintenanceWhitelist() {
-        List<String> stringList = config.getStringList("maintenance.whitelist");
-        List<UUID> uuidList = new ArrayList<>();
-        
-        for (String uuidStr : stringList) {
-            try {
-                uuidList.add(UUID.fromString(uuidStr));
-            } catch (IllegalArgumentException e) {
-                plugin.getLogger().warning("Invalid UUID in maintenance whitelist: " + uuidStr);
-            }
-        }
-        
-        return uuidList;
+        return plugin.getDatabaseManager().getMaintenanceWhitelist();
     }
 
     public void saveConfig() {
@@ -150,23 +139,14 @@ public class ConfigManager {
     }
 
     public void addToWhitelist(UUID uuid) {
-        List<String> whitelist = config.getStringList("maintenance.whitelist");
-        if (!whitelist.contains(uuid.toString())) {
-            whitelist.add(uuid.toString());
-            config.set("maintenance.whitelist", whitelist);
-            saveConfig();
-        }
+        plugin.getDatabaseManager().addToMaintenanceWhitelist(uuid);
     }
 
     public void removeFromWhitelist(UUID uuid) {
-        List<String> whitelist = config.getStringList("maintenance.whitelist");
-        whitelist.remove(uuid.toString());
-        config.set("maintenance.whitelist", whitelist);
-        saveConfig();
+        plugin.getDatabaseManager().removeFromMaintenanceWhitelist(uuid);
     }
 
     public boolean isInWhitelist(UUID uuid) {
-        List<String> whitelist = config.getStringList("maintenance.whitelist");
-        return whitelist.contains(uuid.toString());
+        return plugin.getDatabaseManager().isInMaintenanceWhitelist(uuid);
     }
-} 
+}

--- a/src/main/java/me/dergamer09/bungeesystem/Managers/DatabaseManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/Managers/DatabaseManager.java
@@ -84,6 +84,7 @@ public class DatabaseManager {
         createPlayerDataTable();
         createPunishmentReasonsTable();
         createWarningsTable();
+        createMaintenanceWhitelistTable();
     }
 
     public void close() {
@@ -325,6 +326,19 @@ public class DatabaseManager {
             ProxyServer.getInstance().getLogger().info("§a[BungeeSystem] Player data table created or verified.");
         } catch (SQLException e) {
             ProxyServer.getInstance().getLogger().severe("§c[BungeeSystem] Failed to create player data table: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void createMaintenanceWhitelistTable() {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS maintenance_whitelist (" +
+                        "uuid VARCHAR(36) PRIMARY KEY," +
+                        "added BIGINT NOT NULL)")) {
+            ps.executeUpdate();
+            ProxyServer.getInstance().getLogger().info("§a[BungeeSystem] Maintenance whitelist table created or verified.");
+        } catch (SQLException e) {
+            ProxyServer.getInstance().getLogger().severe("§c[BungeeSystem] Failed to create maintenance whitelist table: " + e.getMessage());
             e.printStackTrace();
         }
     }
@@ -573,5 +587,61 @@ public class DatabaseManager {
         }
         
         return connection != null;
+    }
+
+    public void addToMaintenanceWhitelist(UUID uuid) {
+        if (connection == null) return;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "REPLACE INTO maintenance_whitelist (uuid, added) VALUES (?, ?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setLong(2, System.currentTimeMillis());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            ProxyServer.getInstance().getLogger().severe("§c[BungeeSystem] Failed to add whitelist entry: " + e.getMessage());
+        }
+    }
+
+    public void removeFromMaintenanceWhitelist(UUID uuid) {
+        if (connection == null) return;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "DELETE FROM maintenance_whitelist WHERE uuid = ?")) {
+            ps.setString(1, uuid.toString());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            ProxyServer.getInstance().getLogger().severe("§c[BungeeSystem] Failed to remove whitelist entry: " + e.getMessage());
+        }
+    }
+
+    public boolean isInMaintenanceWhitelist(UUID uuid) {
+        if (connection == null) return false;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT uuid FROM maintenance_whitelist WHERE uuid = ? LIMIT 1")) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            ProxyServer.getInstance().getLogger().severe("§c[BungeeSystem] Failed to check whitelist: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public java.util.List<UUID> getMaintenanceWhitelist() {
+        java.util.List<UUID> list = new java.util.ArrayList<>();
+        if (connection == null) return list;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT uuid FROM maintenance_whitelist")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        list.add(UUID.fromString(rs.getString("uuid")));
+                    } catch (IllegalArgumentException ignored) {
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            ProxyServer.getInstance().getLogger().severe("§c[BungeeSystem] Failed to read whitelist: " + e.getMessage());
+        }
+        return list;
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/commands/SendCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/commands/SendCommand.java
@@ -22,9 +22,18 @@ public class SendCommand extends Command {
                 return;
             }
 
+            ProxiedPlayer player = (ProxiedPlayer) sender;
+            if (MaintenanceCommand.isMaintenanceMode()
+                    && !player.hasPermission("bungeesystem.maintenance.bypass")
+                    && !BungeeSystem.getInstance().getConfigManager().isInWhitelist(player.getUniqueId())) {
+                player.disconnect(new TextComponent(BungeeSystem.getInstance().getConfigManager().getMessage("join.maintenance_kick")
+                        + "\n" + BungeeSystem.getInstance().getConfigManager().getMessage("join.maintenance_kick_info")));
+                return;
+            }
+
             ServerInfo server = BungeeSystem.getInstance().getProxy().getServerInfo(args[0]);
             if (server != null) {
-                ((ProxiedPlayer) sender).connect(server);
+                player.connect(server);
                 sender.sendMessage(ChatColor.GREEN + "Connecting you to " + ChatColor.YELLOW + server.getName() + ChatColor.GREEN + "...");
             } else {
                 sender.sendMessage(ChatColor.RED + "Server not found!");
@@ -41,6 +50,13 @@ public class SendCommand extends Command {
         ServerInfo server = BungeeSystem.getInstance().getProxy().getServerInfo(args[1]);
 
         if (target != null && server != null) {
+            if (MaintenanceCommand.isMaintenanceMode()
+                    && !target.hasPermission("bungeesystem.maintenance.bypass")
+                    && !BungeeSystem.getInstance().getConfigManager().isInWhitelist(target.getUniqueId())) {
+                target.disconnect(new TextComponent(BungeeSystem.getInstance().getConfigManager().getMessage("join.maintenance_kick")
+                        + "\n" + BungeeSystem.getInstance().getConfigManager().getMessage("join.maintenance_kick_info")));
+                return;
+            }
             target.connect(server);
             sender.sendMessage(ChatColor.GREEN + "Sent " + target.getName() + " to " + server.getName());
         } else {

--- a/src/main/java/me/dergamer09/bungeesystem/commands/ServerCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/commands/ServerCommand.java
@@ -44,6 +44,15 @@ public class ServerCommand extends Command {
             return;
         }
 
+        ProxiedPlayer p = (ProxiedPlayer) sender;
+        if (MaintenanceCommand.isMaintenanceMode()
+                && !p.hasPermission("bungeesystem.maintenance.bypass")
+                && !BungeeSystem.getInstance().getConfigManager().isInWhitelist(p.getUniqueId())) {
+            p.disconnect(new TextComponent(BungeeSystem.getInstance().getConfigManager().getMessage("join.maintenance_kick")
+                    + "\n" + BungeeSystem.getInstance().getConfigManager().getMessage("join.maintenance_kick_info")));
+            return;
+        }
+
         String serverName = args[0];
         ServerInfo server = serverMap.get(serverName);
 

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ConfigManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ConfigManager.java
@@ -25,13 +25,15 @@ public class ConfigManager {
     private final Logger logger;
     private final ClassLoader classLoader;
     private final Path dataDirectory;
+    private final me.dergamer09.bungeesystem.velocity.VelocitySystem plugin;
 
     private Configuration config;
     private Configuration messages;
     private File configFile;
     private File messagesFile;
 
-    public ConfigManager(Logger logger, ClassLoader classLoader, Path dataDirectory) {
+    public ConfigManager(me.dergamer09.bungeesystem.velocity.VelocitySystem plugin, Logger logger, ClassLoader classLoader, Path dataDirectory) {
+        this.plugin = plugin;
         this.logger = logger;
         this.classLoader = classLoader;
         this.dataDirectory = dataDirectory;
@@ -115,15 +117,7 @@ public class ConfigManager {
     }
 
     public List<UUID> getMaintenanceWhitelist() {
-        List<String> list = config.getStringList("maintenance.whitelist");
-        List<UUID> uuids = new ArrayList<>();
-        for (String uuidStr : list) {
-            try {
-                uuids.add(UUID.fromString(uuidStr));
-            } catch (IllegalArgumentException ignored) {
-            }
-        }
-        return uuids;
+        return plugin.getDatabaseManager().getWhitelist();
     }
 
     public static String translateColorCodes(String text) {
@@ -160,23 +154,14 @@ public class ConfigManager {
     }
 
     public void addToWhitelist(UUID uuid) {
-        List<String> whitelist = config.getStringList("maintenance.whitelist");
-        if (!whitelist.contains(uuid.toString())) {
-            whitelist.add(uuid.toString());
-            config.set("maintenance.whitelist", whitelist);
-            saveConfig();
-        }
+        plugin.getDatabaseManager().addToWhitelist(uuid);
     }
 
     public void removeFromWhitelist(UUID uuid) {
-        List<String> whitelist = config.getStringList("maintenance.whitelist");
-        whitelist.remove(uuid.toString());
-        config.set("maintenance.whitelist", whitelist);
-        saveConfig();
+        plugin.getDatabaseManager().removeFromWhitelist(uuid);
     }
 
     public boolean isInWhitelist(UUID uuid) {
-        List<String> whitelist = config.getStringList("maintenance.whitelist");
-        return whitelist.contains(uuid.toString());
+        return plugin.getDatabaseManager().isInWhitelist(uuid);
     }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/DatabaseManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/DatabaseManager.java
@@ -1,0 +1,121 @@
+package me.dergamer09.bungeesystem.velocity.Managers;
+
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.md_5.bungee.config.Configuration;
+import org.slf4j.Logger;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class DatabaseManager {
+    private final Configuration config;
+    private final Logger logger;
+    private final ProxyServer server;
+    private Connection connection;
+
+    public DatabaseManager(Configuration config, Logger logger, ProxyServer server) {
+        this.config = config;
+        this.logger = logger;
+        this.server = server;
+    }
+
+    public boolean initialize() {
+        connect();
+        if (connection != null) {
+            createMaintenanceWhitelistTable();
+        }
+        return connection != null;
+    }
+
+    private void connect() {
+        String host = config.getString("mysql.host");
+        String port = config.getString("mysql.port");
+        String database = config.getString("mysql.database");
+        String username = config.getString("mysql.username");
+        String password = config.getString("mysql.password");
+        boolean useSSL = config.getBoolean("mysql.useSSL", false);
+        boolean autoReconnect = config.getBoolean("mysql.autoReconnect", true);
+
+        String url = "jdbc:mysql://" + host + ":" + port + "/" + database +
+                "?useSSL=" + useSSL + "&autoReconnect=" + autoReconnect +
+                "&characterEncoding=utf8&useUnicode=true&allowPublicKeyRetrieval=true";
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+            connection = DriverManager.getConnection(url, username, password);
+            if (connection.isValid(5)) {
+                logger.info("MySQL connection established.");
+            }
+        } catch (Exception e) {
+            logger.error("MySQL connection failed: {}", e.getMessage());
+        }
+    }
+
+    private void createMaintenanceWhitelistTable() {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "CREATE TABLE IF NOT EXISTS maintenance_whitelist (" +
+                        "uuid VARCHAR(36) PRIMARY KEY," +
+                        "added BIGINT NOT NULL)")) {
+            ps.executeUpdate();
+            logger.info("Maintenance whitelist table created or verified.");
+        } catch (SQLException e) {
+            logger.error("Failed to create maintenance whitelist table: {}", e.getMessage());
+        }
+    }
+
+    public void addToWhitelist(UUID uuid) {
+        if (connection == null) return;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "REPLACE INTO maintenance_whitelist (uuid, added) VALUES (?, ?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setLong(2, System.currentTimeMillis());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("Failed to add whitelist entry: {}", e.getMessage());
+        }
+    }
+
+    public void removeFromWhitelist(UUID uuid) {
+        if (connection == null) return;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "DELETE FROM maintenance_whitelist WHERE uuid = ?")) {
+            ps.setString(1, uuid.toString());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("Failed to remove whitelist entry: {}", e.getMessage());
+        }
+    }
+
+    public boolean isInWhitelist(UUID uuid) {
+        if (connection == null) return false;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT uuid FROM maintenance_whitelist WHERE uuid = ? LIMIT 1")) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            logger.error("Failed to check whitelist: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public List<UUID> getWhitelist() {
+        List<UUID> list = new ArrayList<>();
+        if (connection == null) return list;
+        try (PreparedStatement ps = connection.prepareStatement("SELECT uuid FROM maintenance_whitelist")) {
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    try {
+                        list.add(UUID.fromString(rs.getString("uuid")));
+                    } catch (IllegalArgumentException ignored) {
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            logger.error("Failed to read whitelist: {}", e.getMessage());
+        }
+        return list;
+    }
+}

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ListenerManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/ListenerManager.java
@@ -20,6 +20,7 @@ public class ListenerManager {
     public void registerListeners() {
         plugin.getServer().getEventManager().register(plugin, this);
         plugin.getServer().getEventManager().register(plugin, new me.dergamer09.bungeesystem.velocity.listeners.MotdListener(plugin));
+        plugin.getServer().getEventManager().register(plugin, new me.dergamer09.bungeesystem.velocity.listeners.PlayerEventListener(plugin));
     }
 
     // Example listener for disconnects

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/VelocitySystem.java
@@ -16,6 +16,7 @@ import me.dergamer09.bungeesystem.velocity.Managers.VelocityCommandManager;
 import me.dergamer09.bungeesystem.velocity.Managers.ConfigManager;
 import me.dergamer09.bungeesystem.velocity.Managers.ListenerManager;
 import me.dergamer09.bungeesystem.velocity.Managers.MotdManager;
+import me.dergamer09.bungeesystem.velocity.Managers.DatabaseManager;
 import me.dergamer09.bungeesystem.velocity.Runnables.OnlineTimeUpdater;
 
 /**
@@ -32,6 +33,7 @@ public class VelocitySystem {
     private final Metrics.Factory metricsFactory;
 
     private ConfigManager configManager;
+    private DatabaseManager databaseManager;
     private VelocityCommandManager commandManager;
     private ListenerManager listenerManager;
     private MotdManager motdManager;
@@ -54,7 +56,9 @@ public class VelocitySystem {
     public void onProxyInit(ProxyInitializeEvent event) {
         logger.info("BungeeSystem loaded (Velocity compatibility mode).");
         metrics = metricsFactory.make(this, BSTATS_PLUGIN_ID);
-        configManager = new ConfigManager(logger, getClass().getClassLoader(), dataDirectory);
+        configManager = new ConfigManager(this, logger, getClass().getClassLoader(), dataDirectory);
+        databaseManager = new DatabaseManager(configManager.getConfig(), logger, server);
+        databaseManager.initialize();
         motdManager = new MotdManager(configManager);
         commandManager = new VelocityCommandManager(this);
         listenerManager = new ListenerManager(this, logger);
@@ -73,5 +77,6 @@ public class VelocitySystem {
     }
 
     public ConfigManager getConfigManager() { return configManager; }
+    public DatabaseManager getDatabaseManager() { return databaseManager; }
     public MotdManager getMotdManager() { return motdManager; }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/listeners/PlayerEventListener.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/listeners/PlayerEventListener.java
@@ -1,0 +1,28 @@
+package me.dergamer09.bungeesystem.velocity.listeners;
+
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.player.PostLoginEvent;
+import com.velocitypowered.api.proxy.Player;
+import me.dergamer09.bungeesystem.velocity.VelocitySystem;
+import me.dergamer09.bungeesystem.velocity.commands.MaintenanceCommand;
+import net.kyori.adventure.text.Component;
+
+public class PlayerEventListener {
+    private final VelocitySystem plugin;
+
+    public PlayerEventListener(VelocitySystem plugin) {
+        this.plugin = plugin;
+    }
+
+    @Subscribe
+    public void onPostLogin(PostLoginEvent event) {
+        Player player = event.getPlayer();
+        if (MaintenanceCommand.isMaintenanceMode()
+                && !player.hasPermission("bungeesystem.maintenance.bypass")
+                && !plugin.getDatabaseManager().isInWhitelist(player.getUniqueId())) {
+            player.disconnect(Component.text(
+                    plugin.getConfigManager().getMessage("join.maintenance_kick") + "\n" +
+                            plugin.getConfigManager().getMessage("join.maintenance_kick_info")));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- store maintenance whitelist in new `maintenance_whitelist` table
- use database whitelist in config managers
- block `/server` and `/send` when maintenance active
- add Velocity database manager and login listener

## Testing
- `mvn -q -DskipTests package` *(fails: `command not found`)*
- `apt-get update -y` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d77ba4d5c832eaaca3369f126b1ce