### PR TITLE
Fix Velocity PostLoginEvent import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
           <version>3.1.1</version>
           <scope>provided</scope>
       </dependency>
+      <!-- MySQL JDBC driver for database connectivity -->
+      <dependency>
+          <groupId>com.mysql</groupId>
+          <artifactId>mysql-connector-j</artifactId>
+          <version>8.0.33</version>
+      </dependency>
       <dependency>
           <groupId>org.bstats</groupId>
           <artifactId>bstats-bungeecord</artifactId>

--- a/src/main/java/me/dergamer09/bungeesystem/commands/MaintenanceCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/commands/MaintenanceCommand.java
@@ -82,30 +82,45 @@ public class MaintenanceCommand extends Command {
             if (args[0].equalsIgnoreCase("whitelist") && args.length >= 3) {
                 if (args[1].equalsIgnoreCase("add") && args.length >= 3) {
                     ProxiedPlayer target = ProxyServer.getInstance().getPlayer(args[2]);
-                    if (target == null) {
-                        sender.sendMessage(new TextComponent(configManager.getMessage("system.player_not_found", "player", args[2])));
-                        return;
+                    UUID uuid;
+                    String name = args[2];
+
+                    if (target != null) {
+                        uuid = target.getUniqueId();
+                        name = target.getName();
+                    } else {
+                        uuid = plugin.getDatabaseManager().getUUIDFromName(name);
+                        if (uuid == null) {
+                            sender.sendMessage(new TextComponent(configManager.getMessage("system.player_not_found", "player", name)));
+                            return;
+                        }
                     }
-                    
-                    UUID uuid = target.getUniqueId();
+
                     configManager.addToWhitelist(uuid);
-                    sender.sendMessage(new TextComponent(configManager.getMessage("whitelist.player_added", "player", target.getName())));
+                    sender.sendMessage(new TextComponent(configManager.getMessage("whitelist.player_added", "player", name)));
                     return;
                 }
                 
                 if (args[1].equalsIgnoreCase("remove") && args.length >= 3) {
                     ProxiedPlayer target = ProxyServer.getInstance().getPlayer(args[2]);
-                    if (target == null) {
-                        sender.sendMessage(new TextComponent(configManager.getMessage("system.player_not_found", "player", args[2])));
-                        return;
+                    UUID uuid;
+                    String name = args[2];
+
+                    if (target != null) {
+                        uuid = target.getUniqueId();
+                        name = target.getName();
+                    } else {
+                        uuid = plugin.getDatabaseManager().getUUIDFromName(name);
+                        if (uuid == null) {
+                            sender.sendMessage(new TextComponent(configManager.getMessage("system.player_not_found", "player", name)));
+                            return;
+                        }
                     }
-                    
-                    UUID uuid = target.getUniqueId();
+
                     configManager.removeFromWhitelist(uuid);
-                    sender.sendMessage(new TextComponent(configManager.getMessage("whitelist.player_removed", "player", target.getName())));
-                    
-                    // If maintenance is active, kick the player who was just removed from whitelist
-                    if (maintenanceMode && target.isConnected()) {
+                    sender.sendMessage(new TextComponent(configManager.getMessage("whitelist.player_removed", "player", name)));
+
+                    if (maintenanceMode && target != null && target.isConnected()) {
                         target.disconnect(new TextComponent(
                                 configManager.getMessage("join.maintenance_kick") + "\n" +
                                 configManager.getMessage("join.maintenance_kick_info")

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/DatabaseManager.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/Managers/DatabaseManager.java
@@ -118,4 +118,48 @@ public class DatabaseManager {
         }
         return list;
     }
+
+    /**
+     * Retrieve a player's UUID from the database using their name.
+     *
+     * @param playerName the player's name
+     * @return UUID of the player or null if not found
+     */
+    public UUID getUUIDFromName(String playerName) {
+        if (connection == null) {
+            return null;
+        }
+        try {
+            PreparedStatement ps = connection.prepareStatement(
+                    "SELECT uuid FROM player_data WHERE name = ? LIMIT 1");
+            ps.setString(1, playerName);
+
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                UUID uuid = UUID.fromString(rs.getString("uuid"));
+                rs.close();
+                ps.close();
+                return uuid;
+            }
+            rs.close();
+            ps.close();
+
+            ps = connection.prepareStatement(
+                    "SELECT uuid FROM player_stats WHERE name = ? LIMIT 1");
+            ps.setString(1, playerName);
+            rs = ps.executeQuery();
+            if (rs.next()) {
+                UUID uuid = UUID.fromString(rs.getString("uuid"));
+                rs.close();
+                ps.close();
+                return uuid;
+            }
+            rs.close();
+            ps.close();
+            return null;
+        } catch (SQLException e) {
+            logger.error("Failed to get UUID for player {}: {}", playerName, e.getMessage());
+            return null;
+        }
+    }
 }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/commands/MaintenanceCommand.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/commands/MaintenanceCommand.java
@@ -83,25 +83,43 @@ public class MaintenanceCommand implements SimpleCommand {
     private void handleWhitelist(CommandSource sender, String[] args) {
         if (args[1].equalsIgnoreCase("add") && args.length >= 3) {
             Player target = server.getPlayer(args[2]).orElse(null);
-            if (target == null) {
-                sender.sendMessage(Component.text(configManager.getMessage("system.player_not_found", "player", args[2])));
-                return;
+            UUID uuid;
+            String name = args[2];
+
+            if (target != null) {
+                uuid = target.getUniqueId();
+                name = target.getUsername();
+            } else {
+                uuid = plugin.getDatabaseManager().getUUIDFromName(name);
+                if (uuid == null) {
+                    sender.sendMessage(Component.text(configManager.getMessage("system.player_not_found", "player", name)));
+                    return;
+                }
             }
-            UUID uuid = target.getUniqueId();
+
             configManager.addToWhitelist(uuid);
-            sender.sendMessage(Component.text(configManager.getMessage("whitelist.player_added", "player", target.getUsername())));
+            sender.sendMessage(Component.text(configManager.getMessage("whitelist.player_added", "player", name)));
             return;
         }
         if (args[1].equalsIgnoreCase("remove") && args.length >= 3) {
             Player target = server.getPlayer(args[2]).orElse(null);
-            if (target == null) {
-                sender.sendMessage(Component.text(configManager.getMessage("system.player_not_found", "player", args[2])));
-                return;
+            UUID uuid;
+            String name = args[2];
+
+            if (target != null) {
+                uuid = target.getUniqueId();
+                name = target.getUsername();
+            } else {
+                uuid = plugin.getDatabaseManager().getUUIDFromName(name);
+                if (uuid == null) {
+                    sender.sendMessage(Component.text(configManager.getMessage("system.player_not_found", "player", name)));
+                    return;
+                }
             }
-            UUID uuid = target.getUniqueId();
+
             configManager.removeFromWhitelist(uuid);
-            sender.sendMessage(Component.text(configManager.getMessage("whitelist.player_removed", "player", target.getUsername())));
-            if (maintenanceMode && target.isActive()) {
+            sender.sendMessage(Component.text(configManager.getMessage("whitelist.player_removed", "player", name)));
+            if (maintenanceMode && target != null && target.isActive()) {
                 target.disconnect(Component.text(configManager.getMessage("join.maintenance_kick") + "\n" +
                         configManager.getMessage("join.maintenance_kick_info")));
             }

--- a/src/main/java/me/dergamer09/bungeesystem/velocity/listeners/PlayerEventListener.java
+++ b/src/main/java/me/dergamer09/bungeesystem/velocity/listeners/PlayerEventListener.java
@@ -1,7 +1,7 @@
 package me.dergamer09.bungeesystem.velocity.listeners;
 
 import com.velocitypowered.api.event.Subscribe;
-import com.velocitypowered.api.event.player.PostLoginEvent;
+import com.velocitypowered.api.event.connection.PostLoginEvent;
 import com.velocitypowered.api.proxy.Player;
 import me.dergamer09.bungeesystem.velocity.VelocitySystem;
 import me.dergamer09.bungeesystem.velocity.commands.MaintenanceCommand;


### PR DESCRIPTION
## Summary
- correct Velocity `PostLoginEvent` import package
- add MySQL driver dependency so the plugin can connect to MySQL
- allow whitelisting offline players by name in Bungee/Velocity

## Testing
- `javac src/main/java/me/dergamer09/bungeesystem/commands/MaintenanceCommand.java` *(fails: cannot find symbol BungeeSystem, ConfigManager, etc.)*
- `javac src/main/java/me/dergamer09/bungeesystem/velocity/commands/MaintenanceCommand.java` *(fails: package com.velocitypowered.api.command does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687d7b0b0630832e8cdd45cf234bb263