### PR TITLE
Fix missing Adventure serializer dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
           <artifactId>adventure-text-minimessage</artifactId>
           <version>4.14.0</version>
       </dependency>
+      <dependency>
+          <groupId>net.kyori</groupId>
+          <artifactId>adventure-text-serializer-bungeecord</artifactId>
+          <version>4.14.0</version>
+      </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
## Summary
- add Adventure BungeeCord serializer so MOTD listener compiles

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688bccb3986c832e854663df266a0635