### PR TITLE
Add Papermc repo for Adventure serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
           <id>velocitypowered</id>
           <url>https://nexus.velocitypowered.com/repository/maven-public/</url>
       </repository>
+      <repository>
+          <id>papermc</id>
+          <url>https://repo.papermc.io/repository/maven-public/</url>
+      </repository>
   </repositories>
 
   <dependencies>


### PR DESCRIPTION
## Summary
- add the missing papermc maven repository so `adventure-text-serializer-bungeecord` can be resolved

## Testing
- `mvn -q test` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d1b87ded0832eacdd9bd353b8f913